### PR TITLE
Fix rules typo

### DIFF
--- a/.cursor/rules/svelte-rules.mdc
+++ b/.cursor/rules/svelte-rules.mdc
@@ -1,5 +1,5 @@
 ---
-description: Svelete rules
+description: Svelte rules
 globs: *.js, *.ts
 alwaysApply: false
 ---


### PR DESCRIPTION
## Summary
- fix typo in svelte rules description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846dfa653ec832199b3f2ec00774329